### PR TITLE
Implementierung der Methode is_in_lane(...), sowie Unit-Test

### DIFF
--- a/src/overtake_abstract_checker/demo_scenarios.py
+++ b/src/overtake_abstract_checker/demo_scenarios.py
@@ -14,7 +14,6 @@ Folgende Simulationen sind enthalten:
 """
 
 from bppy import BEvent, sync, thread
-
 from overtake_constraints import (END_RELATIVE_POS, MAX_SIM_STEPS,
                                   START_RELATIVE_POS)
 

--- a/src/overtake_abstract_checker/overtake_abstract_checker.py
+++ b/src/overtake_abstract_checker/overtake_abstract_checker.py
@@ -29,9 +29,8 @@ ausgewertet werden können.
 
 import logging
 
-from bppy import All, BProgram, SimpleEventSelectionStrategy, sync, thread
-
 import demo_scenarios
+from bppy import All, BProgram, SimpleEventSelectionStrategy, sync, thread
 from overtake_constraints import (END_RELATIVE_POS, MAX_ACTION_INTERVAL_STEPS,
                                   MAX_SIM_STEPS, MAX_SPEED,
                                   MIN_ACTION_INTERVAL_STEPS, MIN_SIM_STEPS,

--- a/test/test_observation_wrapper.py
+++ b/test/test_observation_wrapper.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 
+from src import main
 from src.observation_wrapper import *
 
 
@@ -207,6 +208,43 @@ class TestObservationWrapper(unittest.TestCase):
     def test_is_in_same_lane_vehicle_not_found(self):
         obs_wrapper = ObservationWrapper(np.array([]))
         self.assertFalse(obs_wrapper.is_in_same_lane(1, 2))
+
+    # Testet, ob das Fahrzeug mit id=0 auf bestimmter Lane ist
+    def test_is_in_lane(self):
+        cfg = main.set_config()
+        env = main.create_env(cfg)
+
+        obs, _ = env.reset()
+        obs_wrapper = ObservationWrapper(obs)
+
+        # in dem Beispiel sind Lanes 4 Einheiten breit und beginnen bei Koordinate 0
+        y_of_vehicle = (obs[0])[0][1]
+        expected_lane = y_of_vehicle / 4
+        # die Fahrzeuge befinden sich zu Beginn nicht immer auf der gleichen Lane,
+        # weshalb die Werte nicht fest gesetzt werden können
+        self.assertTrue(obs_wrapper.is_in_lane(0, expected_lane, env))
+
+    # testet, dass false bei nicht existierender Lane geliefert wird
+    def test_is_in_lane_lane_not_found(self):
+        cfg = main.set_config()
+        env = main.create_env(cfg)
+
+        obs, _ = env.reset()
+        obs_wrapper = ObservationWrapper(obs)
+
+        # Env hat 4 Lanes
+        self.assertFalse(obs_wrapper.is_in_lane(0, 5, env))
+
+    # testet, dass false bei nicht existierendem Vehicle geliefert wird
+    def test_is_in_lane_vehicle_not_found(self):
+        cfg = main.set_config()
+        env = main.create_env(cfg)
+
+        obs, _ = env.reset()
+        obs_wrapper = ObservationWrapper(obs)
+
+        # env hat 7 vehicles
+        self.assertFalse(obs_wrapper.is_in_lane(10, 0, env))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_observation_wrapper.py
+++ b/test/test_observation_wrapper.py
@@ -1,9 +1,17 @@
 import unittest
+from typing import Dict, Any
 
 import numpy as np
 
-from src import main
 from src.observation_wrapper import *
+import gymnasium as gym
+import highway_env as highway
+
+
+def create_test_env(config: Dict[str, Any]) -> Env:
+    env = gym.make('highway-v0', render_mode='rgb_array', config=config)
+    env.reset()
+    return env
 
 
 class TestObservationWrapper(unittest.TestCase):
@@ -76,6 +84,38 @@ class TestObservationWrapper(unittest.TestCase):
             [-75, 0, 0, 0]
         ], dtype=np.float32)
     )
+
+    CONFIG = config = {
+        "centering_position": [0.5, 0.5],
+        "vehicles_count": 1,
+        "controlled_vehicles": 1,
+        "lanes_count": 4,
+        "initial_positions": [
+            [15, 2, 32]  # (x_position, lane_index, speed)
+        ],  # Fixed start positions WIP
+        "observation": {
+            "type": "MultiAgentObservation",
+            "observation_config": {
+                "type": "Kinematics",
+                "vehicles_count": 1,
+                "features": ["x", "y", "vx", "vy"],
+                "normalize": False,
+                "absolute": False,
+                "see_behind": True,
+                "order": "sorted"
+            },
+        },
+        "action": {
+            "type": "MultiAgentAction",
+            "action_config": {
+                "type": "DiscreteMetaAction",
+                "longitudinal": True,
+                "lateral": True,
+                "target_speeds": [0, 5, 10, 15, 20, 25, 30]
+            },
+        },
+        "simulation_frequency": 100
+    }
 
     # is_left_lane_clear tests
 
@@ -211,40 +251,53 @@ class TestObservationWrapper(unittest.TestCase):
 
     # Testet, ob das Fahrzeug mit id=0 auf bestimmter Lane ist
     def test_is_in_lane(self):
-        cfg = main.set_config()
-        env = main.create_env(cfg)
+        env = create_test_env(self.CONFIG)
 
         obs, _ = env.reset()
-        obs_wrapper = ObservationWrapper(obs)
+        obs_wrapper = ObservationWrapper(obs, env)
 
         # in dem Beispiel sind Lanes 4 Einheiten breit und beginnen bei Koordinate 0
         y_of_vehicle = (obs[0])[0][1]
         expected_lane = y_of_vehicle / 4
         # die Fahrzeuge befinden sich zu Beginn nicht immer auf der gleichen Lane,
         # weshalb die Werte nicht fest gesetzt werden können
-        self.assertTrue(obs_wrapper.is_in_lane(0, expected_lane, env))
+        self.assertTrue(obs_wrapper.is_in_lane(0, expected_lane))
+
+    # Testet, ob das Fahrzeug mit id=0 auf bestimmter Lane ist
+    def test_is_in_lane_negativ(self):
+        env = create_test_env(self.CONFIG)
+
+        obs, _ = env.reset()
+        obs_wrapper = ObservationWrapper(obs, env)
+
+        # in dem Beispiel sind Lanes 4 Einheiten breit und beginnen bei Koordinate 0
+        y_of_vehicle = (obs[0])[0][1]
+        not_expected_lane = (y_of_vehicle / 4) + 1
+        if not_expected_lane == 4:
+            not_expected_lane = 1
+        # die Fahrzeuge befinden sich zu Beginn nicht immer auf der gleichen Lane,
+        # weshalb die Werte nicht fest gesetzt werden können
+        self.assertFalse(obs_wrapper.is_in_lane(0, not_expected_lane))
 
     # testet, dass false bei nicht existierender Lane geliefert wird
     def test_is_in_lane_lane_not_found(self):
-        cfg = main.set_config()
-        env = main.create_env(cfg)
+        env = create_test_env(self.CONFIG)
 
         obs, _ = env.reset()
-        obs_wrapper = ObservationWrapper(obs)
+        obs_wrapper = ObservationWrapper(obs, env)
 
         # Env hat 4 Lanes
-        self.assertFalse(obs_wrapper.is_in_lane(0, 5, env))
+        self.assertFalse(obs_wrapper.is_in_lane(0, 5))
 
     # testet, dass false bei nicht existierendem Vehicle geliefert wird
     def test_is_in_lane_vehicle_not_found(self):
-        cfg = main.set_config()
-        env = main.create_env(cfg)
+        env = create_test_env(self.CONFIG)
 
         obs, _ = env.reset()
-        obs_wrapper = ObservationWrapper(obs)
+        obs_wrapper = ObservationWrapper(obs, env)
 
         # env hat 7 vehicles
-        self.assertFalse(obs_wrapper.is_in_lane(10, 0, env))
+        self.assertFalse(obs_wrapper.is_in_lane(10, 0))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_observation_wrapper.py
+++ b/test/test_observation_wrapper.py
@@ -1,11 +1,11 @@
 import unittest
-from typing import Dict, Any
+from typing import Any, Dict
 
+import gymnasium as gym
+import highway_env as highway
 import numpy as np
 
 from src.observation_wrapper import *
-import gymnasium as gym
-import highway_env as highway
 
 
 def create_test_env(config: Dict[str, Any]) -> Env:


### PR DESCRIPTION
PR zu https://github.com/Lukas-K1/Intelligentes_Testen_autonomer_Fahrzeuge/issues/46

Dafür:
 - Methode isInLane() implementiert
 - Dokumentation der Methode
 - Unit Tests der Methode

Aus den reinen Observations kann nicht abgelesen werden, wie viele Lanes existieren. Deshalb wird hier zusätzlich die Env benötigt. Das RoadNetwork bietet dafür die function get_closest_lane_index dem Koordinaten übergeben werden und dazu ein Tupel liefert mit der zugehörigen Lane. Der index der Lane ist dann an Stelle [2] des Ergebnisses.

Ich habe die Behandlung der Randfälle, falls einer der übergebenen Werte nicht da ist oder passt, versucht analog der restlichen Methoden im observation_wrapper zu gestallten -> dann wird immer false geliefert. Bei Einwänden passe ich das gerne an

Gerne Feedback zur Implementierung und dem Code Style (mangels Python Erfahrung) :)