### PR TITLE
#42 Logging der Observations in Datei

### DIFF
--- a/src/observation_logger.py
+++ b/src/observation_logger.py
@@ -1,0 +1,77 @@
+import os
+
+import numpy as np
+from datetime import datetime
+
+
+def generate_filename(base_name: str, extension: str, directory : str) -> str:
+    """
+    Generiert einen Dateinamen mit dem aktuellen Timestamp.
+
+    :param directory: Verzeichnis der Datei
+    :param base_name: Name der Datei.
+    :param extension: Der Dateityp.
+    :return: String, der den Dateinamen enthält .
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"{base_name}_{timestamp}.{extension}"
+    return os.path.join(directory, filename)
+
+
+class ObservationLogger:
+    """
+    Klasse zum Speichern von Observations in einer Datei. Sollte nach jedem Step einmal aufgerufen werden.
+    Standardmäßig wird die Datei im resources/logs Verzeichnis gespeichert. Existiert dieses nicht, wird es erzeugt.
+    Die Daten werden im CSV-Format gespeichert. Der aktuelle Step wird mit gespeichert.
+
+    Note: Kann mit der reset() Methode zurückgesetzt werden.
+
+    :param directory: Verzeichnis, in dem die Datei gespeichert wird.
+    :param format_of_coordinates: Formatierung der Koordinaten in der Observation.
+    """
+
+    def __init__(self, directory: str = "resources/logs", format_of_coordinates: str = "%.6f"):
+        # Ensure the directory exists
+        os.makedirs(directory, exist_ok=True)
+        self.filename = generate_filename("simulation_log", "csv", directory)
+        self.step_count = 0
+        self.format = format_of_coordinates
+
+    def reset(self):
+        self.__init__()
+
+    def save_observation(self, observation):
+        """
+        Speichert die Observation in einer Datei. Neue Einträge werden über eine neue Zeile separiert und den aktuellen
+        Step separiert.
+
+        :param observation: Die Observation.
+        """
+
+        matrix = np.asmatrix(observation[0])
+
+        with open(self.filename, 'a') as f:
+            f.write("Step " + str(self.step_count) + ": \n")
+            self.step_count += 1
+            np.savetxt(f, matrix, newline="\n", delimiter=",", fmt=self.format)
+
+    def read_observations(self) -> []:
+        """
+        Liest die Observations wieder als Matrix aus der Datei ein.
+
+        :return: Die Observation, wie sie gespeichert wurde.
+        """
+        observations = []
+        with open(self.filename, 'r') as f:
+            lines = f.readlines()
+            current_matrix = []
+            for line in lines:
+                if line.startswith("Step"):
+                    if current_matrix:
+                        observations.append(np.array(current_matrix))
+                        current_matrix = []
+                else:
+                    current_matrix.append([float(x) for x in line.strip().split(",")])
+            if current_matrix:
+                observations.append(np.array(current_matrix))
+        return observations

--- a/test/test_observation_logger.py
+++ b/test/test_observation_logger.py
@@ -1,0 +1,49 @@
+import unittest
+
+import gymnasium as gym
+import highway_env as highway
+import numpy as np
+from gymnasium import Env
+
+from src.observation_logger import ObservationLogger
+
+def create_test_env() -> Env:
+    env = gym.make('highway-v0', render_mode='rgb_array', config={"observation": {
+            "type": "MultiAgentObservation",
+            "observation_config": {
+                "type": "Kinematics",
+                "vehicles_count": 1,
+                "features": ["x", "y", "vx", "vy"],
+                "normalize": False,
+                "absolute": False,
+                "see_behind": True,
+                "order": "sorted"
+            },
+        }})
+    env.reset()
+    return env
+
+class TestObservationLogger(unittest.TestCase):
+
+    def test_logger(self):
+        logger = ObservationLogger()
+
+        env = create_test_env()
+        obs, _ = env.reset()
+        logger.save_observation(obs)
+
+        obs = np.round(np.array(obs))
+        saved_obs = np.round(logger.read_observations())
+
+        for i in range(len(obs)):
+            for j in range(len(obs[i])):
+                for k in range(len(obs[i][j])):
+                    self.assertEqual(obs[i][j][k], saved_obs[i][j][k])
+
+    def test_logger_negativ(self):
+        logger = ObservationLogger()
+
+        logger.save_observation(["","",""])
+
+        with self.assertRaises(ValueError):
+            logger.read_observations()


### PR DESCRIPTION
Die observation_logger implementiert, damit Observations gespeichert werden können. Logs werden automatisch mit der aktuellen Uhrzeit benannt und in ihnen die Steps separiert und dann die Matrizen eingefügt. Zusätzlich habe ich noch eine Methode zum Lesen der Observations eingefügt, hauptsächlich um den Logger zu testen.

Die save_observation Methode muss dann immer nach dem Step aufgerufen werden. Da die konkreten Szenarien noch nicht fertig sind, habe ich erstmal keinen Aufruf davon hinzugefügt, das sollte dann mMn in den Szenarien getan werden (eventuell auch im abstrakten Szenario? ich weiß aber nicht, ob da die observations tatsächlich vorliegen (habe es nicht gesehen))